### PR TITLE
Add viewer test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ world.scene.setup();
 world.camera.controls.setLookAt(3, 3, 3, 0, 0, 0);
 ```
 
+## 🧪 Viewer test
+
+Run the glTF viewer example to verify that local models load correctly.
+
+1. Install dependencies
+   ```bash
+   yarn
+   ```
+2. Start the development server
+   ```bash
+   yarn dev
+   ```
+3. Open [`http://localhost:5173/packages/core/src/gltfViewer/example.html`](http://localhost:5173/packages/core/src/gltfViewer/example.html) in your browser.
+4. If an `assets/unit1.glb` file exists it will load automatically. Use the file input in the top left to upload your own `.glb` or `.gltf` file.
+5. Press **R** to rotate the selected model by 90°.
+6. `yarn test` runs the placeholder test script.
+
 
 [npm]: https://img.shields.io/npm/v/@thatopen/components
 [npm-url]: https://www.npmjs.com/package/@thatopen/components

--- a/packages/core/src/gltfViewer/example.html
+++ b/packages/core/src/gltfViewer/example.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GLTF Viewer</title>
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      font-family: "Plus Jakarta Sans", sans-serif;
+      overflow: hidden;
+    }
+    #viewer {
+      width: 100vw;
+      height: 100vh;
+      position: relative;
+    }
+    #fileInput {
+      position: absolute;
+      top: 5px;
+      left: 5px;
+      z-index: 10;
+    }
+  </style>
+</head>
+<body>
+<div id="viewer"></div>
+<input id="fileInput" type="file" accept=".glb,.gltf" />
+<script type="module" src="./example.ts"></script>
+</body>
+</html>

--- a/packages/core/src/gltfViewer/example.ts
+++ b/packages/core/src/gltfViewer/example.ts
@@ -1,0 +1,58 @@
+import * as OBC from "@thatopen/components";
+import * as THREE from "three";
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+
+let selected: THREE.Object3D | null = null;
+export let world: OBC.World;
+
+async function loadGltf(url: string) {
+  const loader = new GLTFLoader();
+  const gltf = await loader.loadAsync(url);
+  return gltf.scene;
+}
+
+async function addModel(url: string) {
+  const scene = await loadGltf(url);
+  world.scene.three.add(scene);
+  selected = scene;
+}
+
+(async () => {
+  const container = document.getElementById("viewer") as HTMLDivElement;
+  const fileInput = document.getElementById("fileInput") as HTMLInputElement;
+
+  const components = new OBC.Components();
+  const worlds = components.get(OBC.Worlds);
+  world = worlds.create<OBC.SimpleScene, OBC.SimpleCamera, OBC.SimpleRenderer>();
+  world.scene = new OBC.SimpleScene(components);
+  world.renderer = new OBC.SimpleRenderer(components, container);
+  world.camera = new OBC.SimpleCamera(components);
+
+  components.init();
+  world.scene.setup();
+  world.camera.controls.setLookAt(5, 5, 5, 0, 0, 0);
+
+  const grids = components.get(OBC.Grids);
+  const grid = grids.create(world);
+  grid.config.primarySize = 1;
+
+  await addModel("/assets/unit1.glb");
+
+  window.addEventListener("keydown", (e) => {
+    if (e.key.toLowerCase() === "r" && selected) {
+      selected.rotateY(Math.PI / 2);
+    }
+  });
+
+  fileInput.addEventListener("change", async () => {
+    const file = fileInput.files?.[0];
+    if (!file) return;
+    if (!file.name.match(/\.gl(b|tf)$/i)) {
+      alert("Invalid file type");
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    if (selected) world.scene.three.remove(selected);
+    await addModel(url);
+  });
+})();


### PR DESCRIPTION
## Summary
- add a "Viewer test" section in README with steps to run the glTF viewer example and load custom models

## Testing
- `yarn install`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_686527a229648330937b6d1e07b1c7d0