### PR TITLE
Add multi-object selection and movement

### DIFF
--- a/packages/viewer/index.ts
+++ b/packages/viewer/index.ts
@@ -1,8 +1,13 @@
 import * as OBC from "@thatopen/components";
 import * as THREE from "three";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { TransformControls } from "three/examples/jsm/controls/TransformControls.js";
 
 let selected: THREE.Object3D | null = null;
+let bbox: THREE.BoxHelper | null = null;
+let controls: TransformControls | null = null;
+const models: THREE.Object3D[] = [];
+const rootMap = new Map<THREE.Object3D, THREE.Object3D>();
 export let world: OBC.World;
 
 function loadGltf(url: string): Promise<THREE.Group> {
@@ -29,20 +34,81 @@ export async function bootstrap() {
   const grid = grids.create(world);
   grid.config.primarySize = 1;
 
-  async function addModel(url: string) {
+  const casters = components.get(OBC.Raycasters);
+  const caster = casters.get(world);
+
+  function selectObject(obj: THREE.Object3D | null) {
+    if (bbox) {
+      world.scene.three.remove(bbox);
+      bbox = null;
+    }
+
+    if (!obj) {
+      controls?.detach();
+      selected = null;
+      return;
+    }
+
+    const root = rootMap.get(obj) ?? obj;
+    selected = root;
+
+    if (!controls) {
+      controls = new TransformControls(
+        world.camera.three,
+        world.renderer.three.domElement,
+      );
+      controls.setMode("translate");
+      controls.showZ = false;
+      controls.addEventListener("dragging-changed", ev => {
+        world.camera.controls.enabled = !ev.value;
+      });
+      controls.addEventListener("change", () => {
+        bbox?.update();
+      });
+      world.scene.three.add(controls);
+    }
+
+    controls.attach(root);
+    bbox = new THREE.BoxHelper(root, 0x00ff00);
+    world.scene.three.add(bbox);
+  }
+
+  async function addModel(url: string, position: THREE.Vector3) {
     const gltf = await loadGltf(url);
+    gltf.scene.position.copy(position);
     gltf.scene.traverse(obj => {
+      rootMap.set(obj, gltf.scene);
       if (obj instanceof THREE.Object3D) obj.name ||= "unit";
     });
     world.scene.three.add(gltf.scene);
-    selected = gltf.scene;
+    models.push(gltf.scene);
+    return gltf.scene;
   }
 
-  await addModel("/assets/unit1.glb");
+  const urls = [
+    "/packages/core/assets/unit1.glb",
+    "/packages/core/assets/unit2.glb",
+    "/packages/core/assets/unit3.glb",
+    "/packages/core/assets/unit4.glb",
+  ];
+  for (let i = 0; i < urls.length; i++) {
+    await addModel(urls[i], new THREE.Vector3(i * 2, 0, 0));
+  }
+
+  world.renderer.three.domElement.addEventListener("pointerdown", () => {
+    if (controls && (controls as any).dragging) return;
+    const result = caster.castRay(models);
+    if (result) {
+      selectObject(result.object as THREE.Object3D);
+    } else {
+      selectObject(null);
+    }
+  });
 
   window.addEventListener("keydown", e => {
     if (e.key.toLowerCase() === "r" && selected) {
       selected.rotateY(Math.PI / 2);
+      bbox?.update();
     }
   });
 
@@ -54,7 +120,9 @@ export async function bootstrap() {
       return;
     }
     const url = URL.createObjectURL(file);
-    if (selected) world.scene.three.remove(selected);
-    await addModel(url);
+    const obj = await addModel(url, new THREE.Vector3(models.length * 2, 0, 0));
+    selectObject(obj);
   });
 }
+
+bootstrap();


### PR DESCRIPTION
## Summary
- load four demo GLB models
- allow selecting objects via raycaster
- enable moving selected model with transform controls
- show green bounding box when selected
- keep rotation on `R` when model is selected

## Testing
- `yarn install`
- `yarn test` *(fails: ENOENT no such file or directory '/workspace/ac_engine_components/assets/unit1.glb')*

------
https://chatgpt.com/codex/tasks/task_e_686d669ba2188330b452187a1316d1f5