### PR TITLE
chore: remove components-front from viewer

### DIFF
--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -11,8 +11,7 @@
     "@thatopen/components": "workspace:*",
     "jspdf": "^3.0.1",
     "three": "^0.175.0",
-    "@thatopen/components-front": "workspace:*",
-    "web-ifc": "^0.0.0"
+    "web-ifc": "0.0.68"
   },
   "devDependencies": {
     "vite": "^7.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1730,6 +1730,7 @@ __metadata:
     jspdf: ^3.0.1
     three: ^0.175.0
     vite: ^7.0.4
+    web-ifc: 0.0.68
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary
- remove @thatopen/components-front from viewer example dependencies
- pin web-ifc dependency to valid version

## Testing
- `yarn install`
- `yarn workspace @thatopen/viewer-example dev`

------
https://chatgpt.com/codex/tasks/task_e_68a37abe8bc8833086c0123e13bb4e91