### PR TITLE
feat(viewer): add ParameterTest banner and unit dimensions

### DIFF
--- a/packages/viewer/index.ts
+++ b/packages/viewer/index.ts
@@ -63,6 +63,88 @@ let controlsHelper: THREE.Object3D | null = null;
 // Maps any child mesh to its root model for easy selection lookups
 const rootMap = new Map<THREE.Object3D, THREE.Object3D>();
 
+let activeClip: { root: THREE.Object3D; plane: THREE.Plane } | null = null;
+const transparentMats = new Map<THREE.Material, number>();
+
+export function resetVisuals() {
+  if (activeClip) {
+    activeClip.root.traverse(obj => {
+      if ((obj as any).isMesh) {
+        const mesh = obj as THREE.Mesh;
+        const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+        mats.forEach(m => (m.clippingPlanes = undefined));
+      }
+    });
+    activeClip = null;
+  }
+  transparentMats.forEach((o, m) => {
+    m.opacity = o;
+    if (o >= 1) m.transparent = false;
+  });
+  transparentMats.clear();
+  if (world?.renderer?.three) {
+    world.renderer.three.localClippingEnabled = false;
+  }
+}
+
+function applyClip(root: THREE.Object3D, side: "A" | "B" | "C" | "D" | "E") {
+  resetVisuals();
+  const box = new THREE.Box3().setFromObject(root);
+  const center = box.getCenter(new THREE.Vector3());
+  const normal = new THREE.Vector3();
+  switch (side) {
+    case "A":
+      normal.set(-1, 0, 0);
+      break;
+    case "B":
+      normal.set(0, 0, -1);
+      break;
+    case "C":
+      normal.set(1, 0, 0);
+      break;
+    case "D":
+      normal.set(0, 0, 1);
+      break;
+    case "E":
+      normal.set(0, -1, 0);
+      break;
+  }
+  const plane = new THREE.Plane(normal, -normal.dot(center));
+  plane.applyMatrix4(root.matrixWorld);
+  root.traverse(obj => {
+    if ((obj as any).isMesh) {
+      const mesh = obj as THREE.Mesh;
+      const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+      mats.forEach(m => (m.clippingPlanes = [plane]));
+    }
+  });
+  world.renderer.three.localClippingEnabled = true;
+  activeClip = { root, plane };
+}
+
+function applyTransparency(root: THREE.Object3D) {
+  resetVisuals();
+  root.traverse(obj => {
+    if ((obj as any).isMesh) {
+      const mesh = obj as THREE.Mesh;
+      const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+      mats.forEach(m => {
+        if (!transparentMats.has(m)) transparentMats.set(m, m.opacity);
+        m.transparent = true;
+        m.opacity = 0.6;
+      });
+    }
+  });
+}
+
+export function clipSelected(side: "A" | "B" | "C" | "D" | "E") {
+  if (selected) applyClip(selected, side);
+}
+
+export function makeTransparentSelected() {
+  if (selected) applyTransparency(selected);
+}
+
 // Group holding the six nudge arrows. nudgeTargets is the list of meshes used
 // for raycasting interaction.
 let nudgeGroup: THREE.Group | null = null;
@@ -686,6 +768,7 @@ function findCartGroup(obj: THREE.Object3D | null): THREE.Object3D | null {
 }
 
 export function selectObject(obj: THREE.Object3D | null, additive = false) {
+  resetVisuals();
   if (!additive) {
     selection.forEach(o => {
       world.scene.three.remove(boxMap.get(o)!);
@@ -771,7 +854,7 @@ export function selectObject(obj: THREE.Object3D | null, additive = false) {
 async function openInfoForUrl(url: string) {
   try {
     const { root } = await loadIfc(url);
-    const info = analyzeUnit(root, url);
+    const info = await analyzeUnit(root, url);
     metaCache.set(root, info);
     showInfo(root);
   } catch (e) {
@@ -1190,7 +1273,7 @@ export async function bootstrap() {
     root.userData.url = url;
     layoutMap.set(id, { id, url, pos: [position.x, position.y, position.z], rot: root.rotation.y, level });
     saveLayout();
-    const info = analyzeUnit(root, url);
+    const info = await analyzeUnit(root, url);
     metaCache.set(root, info);
     addUnitItem(root, url);
     addCartItem(root);

--- a/packages/viewer/index.ts
+++ b/packages/viewer/index.ts
@@ -30,6 +30,7 @@ import {
   renderMeta,
   clearInfo,
 } from "./sidebar";
+import { clearDimensionsCache } from "./src/logic/dimensions";
 import {
   initFloors,
   addUnitToLevel,
@@ -833,6 +834,13 @@ export function selectObject(obj: THREE.Object3D | null, additive = false) {
         world.scene.three.add(helper);
         controls = c;
         controlsHelper = helper as THREE.Object3D;
+        c.addEventListener("dragging-changed", e => {
+          if (!e.value && selected) {
+            selected.updateWorldMatrix(true, true);
+            clearDimensionsCache(selected);
+            if (sidebarEl?.dataset.mode === "info") renderMeta(selected);
+          }
+        });
       } else {
         console.warn("[IFC] incompatible TransformControls instance");
         controls = null;
@@ -1767,14 +1775,18 @@ export async function bootstrap() {
       o.position.y = Math.round(o.position.y / vstep) * vstep;
       o.position.z = Math.round(o.position.z / step) * step;
       setActiveFloor(Math.round(o.position.y / vstep));
-      o.updateMatrixWorld();
+      o.updateWorldMatrix(true, true);
       updateLayout(o);
+      clearDimensionsCache(o);
     });
     if (controls && typeof (controls as any).updateMatrixWorld === "function") {
       controls.updateMatrixWorld(true);
     }
     updateBoxes();
-    if (selection.size === 1 && selected) attachNudge(selected);
+    if (selection.size === 1 && selected) {
+      attachNudge(selected);
+      if (sidebarEl?.dataset.mode === "info") renderMeta(selected);
+    }
     e.preventDefault();
   };
   window.addEventListener("keydown", keyHandler, true);

--- a/packages/viewer/sidebar.ts
+++ b/packages/viewer/sidebar.ts
@@ -26,6 +26,7 @@ export interface UnitMeta {
     height: number;
     area?: number;
     volume?: number;
+    source: "qto" | "box";
   };
   parameterTests?: { raw: string; side: "A" | "B" | "C" | "D" | "E" }[];
 }
@@ -294,7 +295,10 @@ export async function analyzeUnit(
   meta.mats = Array.from(mats.values());
   meta.layers = Array.from(layers);
   meta.parameterTests = await getParameterTests(group as FRAGS.FragmentsGroup);
-  meta.dims = await getUnitDimensions(group as FRAGS.FragmentsGroup);
+  meta.dims = await getUnitDimensions(group as FRAGS.FragmentsGroup, {
+    modelID: (group as any).modelID,
+    expressID: (group as any).expressID,
+  });
   return meta;
 }
 
@@ -331,7 +335,10 @@ function countTris(mesh: THREE.Mesh) {
 export async function renderMeta(group: THREE.Object3D) {
   const meta = metaCache.get(group);
   if (!meta) return;
-  meta.dims = await getUnitDimensions(group as FRAGS.FragmentsGroup);
+  meta.dims = await getUnitDimensions(group as FRAGS.FragmentsGroup, {
+    modelID: (group as any).modelID,
+    expressID: (group as any).expressID,
+  });
   metaTable.innerHTML = "";
   const add = (k: string, v: string) => {
     const tr = document.createElement("tr");

--- a/packages/viewer/sidebar.ts
+++ b/packages/viewer/sidebar.ts
@@ -1,7 +1,7 @@
 import * as THREE from "three";
 import * as FRAGS from "@thatopen/fragments";
 import * as WEBIFC from "web-ifc";
-import { IfcPropertiesUtils } from "@thatopen/components";
+import { getUnitDimensions } from "./src/logic/dimensions";
 
 import {
   selectObject,
@@ -27,7 +27,7 @@ export interface UnitMeta {
     area?: number;
     volume?: number;
   };
-  parameterTest?: string | null;
+  parameterTests?: { raw: string; side: "A" | "B" | "C" | "D" | "E" }[];
 }
 
 export const metaCache = new WeakMap<THREE.Object3D, UnitMeta>();
@@ -48,7 +48,7 @@ let toggleBtn: HTMLButtonElement;
 let tabBtn: HTMLElement;
 let pdfOptions: HTMLElement;
 let jsonButtons: HTMLElement;
-let paramBanner: HTMLDivElement;
+let paramContainer: HTMLDivElement;
 
 export function initSidebar() {
   sidebar = document.getElementById("sidebar") as HTMLElement;
@@ -63,10 +63,9 @@ export function initSidebar() {
   tabBtn = document.getElementById("sidebarTab") as HTMLElement;
   pdfOptions = document.getElementById("pdfOptions") as HTMLElement;
   jsonButtons = document.getElementById("jsonButtons") as HTMLElement;
-  paramBanner = document.createElement("div");
-  paramBanner.className = "param-banner";
-  paramBanner.hidden = true;
-  panelInfo.prepend(paramBanner);
+  paramContainer = document.createElement("div");
+  paramContainer.hidden = true;
+  panelInfo.prepend(paramContainer);
 
   const toggle = () => sidebar.classList.toggle("collapsed");
   toggleBtn.onclick = toggle;
@@ -294,100 +293,45 @@ export async function analyzeUnit(
   });
   meta.mats = Array.from(mats.values());
   meta.layers = Array.from(layers);
-  meta.parameterTest = await getParameterTest(group as FRAGS.FragmentsGroup);
+  meta.parameterTests = await getParameterTests(group as FRAGS.FragmentsGroup);
   meta.dims = await getUnitDimensions(group as FRAGS.FragmentsGroup);
   return meta;
 }
 
-async function getParameterTest(group: FRAGS.FragmentsGroup) {
+async function getParameterTests(group: FRAGS.FragmentsGroup) {
+  const out: { raw: string; side: "A" | "B" | "C" | "D" | "E" }[] = [];
   try {
     const psets = await group.getAllPropertiesOfType(WEBIFC.IFCPROPERTYSET);
-    if (!psets) return null;
+    if (!psets) return out;
     for (const pset of Object.values(psets) as any[]) {
       const props = pset.HasProperties || [];
       for (const h of props) {
         const prop = await group.getProperties(h.value);
         if (prop?.Name?.value === "ParameterTest") {
-          const val = prop.NominalValue?.value;
-          return val !== undefined ? String(val) : null;
+          const raw = String(prop.NominalValue?.value ?? "");
+          const side = raw.trim().toUpperCase()[0] as any;
+          if (["A", "B", "C", "D", "E"].includes(side)) {
+            out.push({ raw, side });
+          }
         }
-      }
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-async function getUnitDimensions(group: FRAGS.FragmentsGroup) {
-  const factor = await IfcPropertiesUtils.getUnits(group);
-  let width: number | undefined;
-  let depth: number | undefined;
-  let height: number | undefined;
-  let area: number | undefined;
-  let volume: number | undefined;
-  try {
-    const qsets = await group.getAllPropertiesOfType(WEBIFC.IFCELEMENTQUANTITY);
-    if (qsets) {
-      for (const qset of Object.values(qsets) as any[]) {
-        if (qset.Name?.value !== "BaseQuantities") continue;
-        const ids = await IfcPropertiesUtils.getQsetQuantities(group, qset.expressID);
-        if (!ids) break;
-        for (const id of ids) {
-          const q = await group.getProperties(id);
-          const name = q?.Name?.value as string | undefined;
-          const { value } = await IfcPropertiesUtils.getQuantityValue(group, id);
-          if (value === null || value === undefined || !name) continue;
-          const num = Number(value);
-          const lname = name.toLowerCase();
-          if (lname === "width") width = num * factor;
-          else if (lname === "length" || lname === "depth") depth = num * factor;
-          else if (lname === "height") height = num * factor;
-          else if (lname.includes("area")) area = num * factor * factor;
-          else if (lname.includes("volume")) volume = num * factor * factor * factor;
-        }
-        break;
       }
     }
   } catch {
     /* empty */
   }
-  if (width === undefined || depth === undefined || height === undefined) {
-    const box = new THREE.Box3().setFromObject(group);
-    const size = box.getSize(new THREE.Vector3());
-    width ??= size.x * factor;
-    depth ??= size.z * factor;
-    height ??= size.y * factor;
-  }
-  if (area === undefined && width !== undefined && depth !== undefined) {
-    area = width * depth;
-  }
-  if (
-    volume === undefined &&
-    width !== undefined &&
-    depth !== undefined &&
-    height !== undefined
-  ) {
-    volume = width * depth * height;
-  }
-  const round = (n: number) => Math.round(n * 100) / 100;
-  return {
-    width: round(width ?? 0),
-    depth: round(depth ?? 0),
-    height: round(height ?? 0),
-    area: area !== undefined ? round(area) : undefined,
-    volume: volume !== undefined ? round(volume) : undefined,
-  };
+  return out;
 }
+
 
 function countTris(mesh: THREE.Mesh) {
   const g = mesh.geometry;
   return g.index ? g.index.count / 3 : g.attributes.position.count / 3;
 }
 
-export function renderMeta(group: THREE.Object3D) {
+export async function renderMeta(group: THREE.Object3D) {
   const meta = metaCache.get(group);
   if (!meta) return;
+  meta.dims = await getUnitDimensions(group as FRAGS.FragmentsGroup);
   metaTable.innerHTML = "";
   const add = (k: string, v: string) => {
     const tr = document.createElement("tr");
@@ -395,33 +339,31 @@ export function renderMeta(group: THREE.Object3D) {
     metaTable.appendChild(tr);
   };
 
-  if (paramBanner) {
-    paramBanner.innerHTML = "";
-    if (meta.parameterTest) {
+  if (paramContainer) {
+    paramContainer.innerHTML = "";
+    const tests = meta.parameterTests || [];
+    tests.forEach(t => {
+      const banner = document.createElement("div");
+      banner.className = "param-banner";
       const msg = document.createElement("div");
-      msg.textContent = `ParameterTest: ${meta.parameterTest}`;
-      const sides: Array<"A" | "B" | "C" | "D" | "E"> = ["A", "B", "C", "D", "E"];
-      const btnWrap = document.createElement("div");
-      sides.forEach(s => {
-        const b = document.createElement("button");
-        b.textContent = `Open side ${s}`;
-        b.onclick = () => clipSelected(s);
-        btnWrap.appendChild(b);
-      });
+      msg.textContent = `ParameterTest: ${t.raw}`;
+      const openBtn = document.createElement("button");
+      openBtn.textContent = `Open side ${t.side}`;
+      openBtn.onclick = () => clipSelected(t.side);
       const tBtn = document.createElement("button");
       tBtn.textContent = "Make transparent";
       tBtn.onclick = () => makeTransparentSelected();
       const igBtn = document.createElement("button");
       igBtn.textContent = "Ignore";
       igBtn.onclick = () => {
-        paramBanner.hidden = true;
+        banner.remove();
         resetVisuals();
+        if (!paramContainer.childElementCount) paramContainer.hidden = true;
       };
-      paramBanner.append(msg, btnWrap, tBtn, igBtn);
-      paramBanner.hidden = false;
-    } else {
-      paramBanner.hidden = true;
-    }
+      banner.append(msg, openBtn, tBtn, igBtn);
+      paramContainer.appendChild(banner);
+    });
+    paramContainer.hidden = tests.length === 0;
   }
   add("File", meta.file);
   add("Meshes", String(meta.meshes));
@@ -445,5 +387,8 @@ export function renderMeta(group: THREE.Object3D) {
 
 export function clearInfo() {
   metaTable.innerHTML = "";
-  if (paramBanner) paramBanner.hidden = true;
+  if (paramContainer) {
+    paramContainer.innerHTML = "";
+    paramContainer.hidden = true;
+  }
 }

--- a/packages/viewer/sidebar.ts
+++ b/packages/viewer/sidebar.ts
@@ -1,7 +1,16 @@
 import * as THREE from "three";
 import * as FRAGS from "@thatopen/fragments";
+import * as WEBIFC from "web-ifc";
+import { IfcPropertiesUtils } from "@thatopen/components";
 
-import { selectObject, downloadLayoutJson, importLayoutFromFile } from "./index";
+import {
+  selectObject,
+  downloadLayoutJson,
+  importLayoutFromFile,
+  clipSelected,
+  makeTransparentSelected,
+  resetVisuals,
+} from "./index";
 import { exportToPdf } from "./utils/exportPdf";
 
 export interface UnitMeta {
@@ -11,6 +20,14 @@ export interface UnitMeta {
   mats: { name: string; color: string; texture?: string }[];
   layers: string[];
   origin: [number, number, number];
+  dims?: {
+    width: number;
+    depth: number;
+    height: number;
+    area?: number;
+    volume?: number;
+  };
+  parameterTest?: string | null;
 }
 
 export const metaCache = new WeakMap<THREE.Object3D, UnitMeta>();
@@ -31,6 +48,7 @@ let toggleBtn: HTMLButtonElement;
 let tabBtn: HTMLElement;
 let pdfOptions: HTMLElement;
 let jsonButtons: HTMLElement;
+let paramBanner: HTMLDivElement;
 
 export function initSidebar() {
   sidebar = document.getElementById("sidebar") as HTMLElement;
@@ -45,6 +63,10 @@ export function initSidebar() {
   tabBtn = document.getElementById("sidebarTab") as HTMLElement;
   pdfOptions = document.getElementById("pdfOptions") as HTMLElement;
   jsonButtons = document.getElementById("jsonButtons") as HTMLElement;
+  paramBanner = document.createElement("div");
+  paramBanner.className = "param-banner";
+  paramBanner.hidden = true;
+  panelInfo.prepend(paramBanner);
 
   const toggle = () => sidebar.classList.toggle("collapsed");
   toggleBtn.onclick = toggle;
@@ -234,7 +256,10 @@ export function removeCartItem(group: THREE.Object3D) {
   cartMap.delete(group);
 }
 
-export function analyzeUnit(group: THREE.Object3D, url: string): UnitMeta {
+export async function analyzeUnit(
+  group: THREE.Object3D,
+  url: string,
+): Promise<UnitMeta> {
   const zero = (group.userData as any).zero as THREE.Vector3 | undefined;
   const meta: UnitMeta = {
     file: url.split("/").pop() || url,
@@ -269,7 +294,90 @@ export function analyzeUnit(group: THREE.Object3D, url: string): UnitMeta {
   });
   meta.mats = Array.from(mats.values());
   meta.layers = Array.from(layers);
+  meta.parameterTest = await getParameterTest(group as FRAGS.FragmentsGroup);
+  meta.dims = await getUnitDimensions(group as FRAGS.FragmentsGroup);
   return meta;
+}
+
+async function getParameterTest(group: FRAGS.FragmentsGroup) {
+  try {
+    const psets = await group.getAllPropertiesOfType(WEBIFC.IFCPROPERTYSET);
+    if (!psets) return null;
+    for (const pset of Object.values(psets) as any[]) {
+      const props = pset.HasProperties || [];
+      for (const h of props) {
+        const prop = await group.getProperties(h.value);
+        if (prop?.Name?.value === "ParameterTest") {
+          const val = prop.NominalValue?.value;
+          return val !== undefined ? String(val) : null;
+        }
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function getUnitDimensions(group: FRAGS.FragmentsGroup) {
+  const factor = await IfcPropertiesUtils.getUnits(group);
+  let width: number | undefined;
+  let depth: number | undefined;
+  let height: number | undefined;
+  let area: number | undefined;
+  let volume: number | undefined;
+  try {
+    const qsets = await group.getAllPropertiesOfType(WEBIFC.IFCELEMENTQUANTITY);
+    if (qsets) {
+      for (const qset of Object.values(qsets) as any[]) {
+        if (qset.Name?.value !== "BaseQuantities") continue;
+        const ids = await IfcPropertiesUtils.getQsetQuantities(group, qset.expressID);
+        if (!ids) break;
+        for (const id of ids) {
+          const q = await group.getProperties(id);
+          const name = q?.Name?.value as string | undefined;
+          const { value } = await IfcPropertiesUtils.getQuantityValue(group, id);
+          if (value === null || value === undefined || !name) continue;
+          const num = Number(value);
+          const lname = name.toLowerCase();
+          if (lname === "width") width = num * factor;
+          else if (lname === "length" || lname === "depth") depth = num * factor;
+          else if (lname === "height") height = num * factor;
+          else if (lname.includes("area")) area = num * factor * factor;
+          else if (lname.includes("volume")) volume = num * factor * factor * factor;
+        }
+        break;
+      }
+    }
+  } catch {
+    /* empty */
+  }
+  if (width === undefined || depth === undefined || height === undefined) {
+    const box = new THREE.Box3().setFromObject(group);
+    const size = box.getSize(new THREE.Vector3());
+    width ??= size.x * factor;
+    depth ??= size.z * factor;
+    height ??= size.y * factor;
+  }
+  if (area === undefined && width !== undefined && depth !== undefined) {
+    area = width * depth;
+  }
+  if (
+    volume === undefined &&
+    width !== undefined &&
+    depth !== undefined &&
+    height !== undefined
+  ) {
+    volume = width * depth * height;
+  }
+  const round = (n: number) => Math.round(n * 100) / 100;
+  return {
+    width: round(width ?? 0),
+    depth: round(depth ?? 0),
+    height: round(height ?? 0),
+    area: area !== undefined ? round(area) : undefined,
+    volume: volume !== undefined ? round(volume) : undefined,
+  };
 }
 
 function countTris(mesh: THREE.Mesh) {
@@ -286,6 +394,35 @@ export function renderMeta(group: THREE.Object3D) {
     tr.innerHTML = `<th>${k}</th><td>${v}</td>`;
     metaTable.appendChild(tr);
   };
+
+  if (paramBanner) {
+    paramBanner.innerHTML = "";
+    if (meta.parameterTest) {
+      const msg = document.createElement("div");
+      msg.textContent = `ParameterTest: ${meta.parameterTest}`;
+      const sides: Array<"A" | "B" | "C" | "D" | "E"> = ["A", "B", "C", "D", "E"];
+      const btnWrap = document.createElement("div");
+      sides.forEach(s => {
+        const b = document.createElement("button");
+        b.textContent = `Open side ${s}`;
+        b.onclick = () => clipSelected(s);
+        btnWrap.appendChild(b);
+      });
+      const tBtn = document.createElement("button");
+      tBtn.textContent = "Make transparent";
+      tBtn.onclick = () => makeTransparentSelected();
+      const igBtn = document.createElement("button");
+      igBtn.textContent = "Ignore";
+      igBtn.onclick = () => {
+        paramBanner.hidden = true;
+        resetVisuals();
+      };
+      paramBanner.append(msg, btnWrap, tBtn, igBtn);
+      paramBanner.hidden = false;
+    } else {
+      paramBanner.hidden = true;
+    }
+  }
   add("File", meta.file);
   add("Meshes", String(meta.meshes));
   add("Triangles", String(meta.tris));
@@ -295,8 +432,18 @@ export function renderMeta(group: THREE.Object3D) {
     const rows = meta.mats.map(m => `${m.name || "mat"} #${m.color}`).join(", ");
     add("Materials", rows);
   }
+  if (meta.dims) {
+    const d = meta.dims;
+    add(
+      "Dimensions",
+      `${d.width.toFixed(2)} × ${d.depth.toFixed(2)} × ${d.height.toFixed(2)} m`,
+    );
+    if (d.area !== undefined) add("Area", `${d.area.toFixed(2)} m²`);
+    if (d.volume !== undefined) add("Volume", `${d.volume.toFixed(2)} m³`);
+  }
 }
 
 export function clearInfo() {
   metaTable.innerHTML = "";
+  if (paramBanner) paramBanner.hidden = true;
 }

--- a/packages/viewer/src/ifc/loader.ts
+++ b/packages/viewer/src/ifc/loader.ts
@@ -2,6 +2,11 @@ import * as OBC from '@thatopen/components';
 import * as THREE from 'three';
 import { toUint8Array } from './bytes';
 
+export const ifcCache = new Map<
+  string,
+  { bytes: Uint8Array; parsed?: { modelID: number; root: THREE.Object3D } }
+>();
+
 let components: OBC.Components | null = null;
 let ifcLoader: any;
 
@@ -27,11 +32,31 @@ export async function setupIfc(world?: any) {
   return ifcLoader;
 }
 
-export async function loadIfc(source: string | File | Uint8Array): Promise<{ modelID: number; root: THREE.Object3D }> {
+export async function loadIfc(
+  source: string | File | Uint8Array,
+): Promise<{ modelID: number; root: THREE.Object3D }> {
   if (!ifcLoader) throw new Error('IFC loader not initialized');
+
+  if (typeof source === 'string') {
+    const url = source;
+    const cached = ifcCache.get(url);
+    if (cached?.parsed) return cached.parsed;
+    const bytes = cached?.bytes || (await loadIfcBytes(url));
+    try {
+      const model: any = await ifcLoader.load(bytes.slice() as any);
+      const root: any = model?.mesh || model?.root || model?.object || model;
+      const modelID: number = model?.modelID || root?.modelID || 0;
+      ifcCache.set(url, { bytes, parsed: { modelID, root } });
+      return { modelID, root };
+    } catch (error: any) {
+      console.error(`[IFC] load error ${url}`, error);
+      throw error;
+    }
+  }
+
   const bytes = await toUint8Array(source);
-  const name = typeof source === 'string' ? source.split('/').pop() || source : source instanceof File ? source.name : 'bytes';
-  const type = source instanceof Uint8Array ? 'bytes' : typeof source === 'string' ? 'url' : 'file';
+  const name = source instanceof File ? source.name : 'bytes';
+  const type = source instanceof Uint8Array ? 'bytes' : 'file';
   console.log(`[IFC] loading ${name} (${type})`);
   try {
     const model: any = await ifcLoader.load(bytes.slice() as any);
@@ -43,10 +68,22 @@ export async function loadIfc(source: string | File | Uint8Array): Promise<{ mod
     console.error(`[IFC] load error ${name}`, error);
     const msg = String(error?.message || error);
     if (msg.includes('magic word')) {
-      console.warn('[IFC] failed to initialize web-ifc WASM. Check that web-ifc.wasm is served from /public/wasm/ with application/wasm MIME type.');
+      console.warn(
+        '[IFC] failed to initialize web-ifc WASM. Check that web-ifc.wasm is served from /public/wasm/ with application/wasm MIME type.',
+      );
     }
     throw error;
   }
+}
+
+export async function loadIfcBytes(url: string): Promise<Uint8Array> {
+  const cached = ifcCache.get(url);
+  if (cached?.bytes) return cached.bytes;
+  console.log(`[IFC] streaming ${url}`);
+  const res = await fetch(url);
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  ifcCache.set(url, { bytes });
+  return bytes;
 }
 
 export function disposeIfc(modelID: number): void {

--- a/packages/viewer/src/ifc/loader.ts
+++ b/packages/viewer/src/ifc/loader.ts
@@ -17,18 +17,11 @@ export async function setupIfc(world?: any) {
   }
   components = (world && (world.components || world._components)) || new OBC.Components();
   ifcLoader = components.get(OBC.IfcLoader as any);
-  if (ifcLoader?.setup) await ifcLoader.setup();
   if (ifcLoader?.settings) {
     ifcLoader.settings.wasm = { path: '/wasm/', absolute: true };
-    const wasmUrl = '/wasm/web-ifc.wasm';
-    console.log('[IFC] setup wasm path: /wasm/');
-    try {
-      const res = await fetch(wasmUrl, { method: 'HEAD' });
-      if (!res.ok) console.warn(`[IFC] web-ifc.wasm not found at ${wasmUrl}`);
-    } catch {
-      console.warn(`[IFC] could not access ${wasmUrl}. Ensure the file exists and has the correct MIME type.`);
-    }
   }
+  if (ifcLoader?.setup) await ifcLoader.setup();
+  console.log('[IFC] setup wasm path: /wasm/');
   return ifcLoader;
 }
 
@@ -40,13 +33,26 @@ export async function loadIfc(
   if (typeof source === 'string') {
     const url = source;
     const cached = ifcCache.get(url);
-    if (cached?.parsed) return cached.parsed;
+    if (cached?.parsed) {
+      const { modelID, root } = cached.parsed;
+      const clone =
+        typeof (root as any).cloneGroup === 'function'
+          ? (root as any).cloneGroup()
+          : root.clone(true);
+      (clone as any).modelID = modelID;
+      return { modelID, root: clone };
+    }
     const bytes = cached?.bytes || (await loadIfcBytes(url));
     try {
       const model: any = await ifcLoader.load(bytes.slice() as any);
-      const root: any = model?.mesh || model?.root || model?.object || model;
-      const modelID: number = model?.modelID || root?.modelID || 0;
-      ifcCache.set(url, { bytes, parsed: { modelID, root } });
+      const base: any = model?.mesh || model?.root || model?.object || model;
+      const modelID: number = model?.modelID || base?.modelID || 0;
+      ifcCache.set(url, { bytes, parsed: { modelID, root: base } });
+      const root =
+        typeof (base as any).cloneGroup === 'function'
+          ? (base as any).cloneGroup()
+          : base.clone(true);
+      (root as any).modelID = modelID;
       return { modelID, root };
     } catch (error: any) {
       console.error(`[IFC] load error ${url}`, error);

--- a/packages/viewer/src/logic/dimensions.ts
+++ b/packages/viewer/src/logic/dimensions.ts
@@ -1,0 +1,129 @@
+import * as THREE from "three";
+import * as FRAGS from "@thatopen/fragments";
+import * as WEBIFC from "web-ifc";
+import { IfcPropertiesUtils } from "@thatopen/components";
+
+export interface Dimensions {
+  width: number;
+  depth: number;
+  height: number;
+  area?: number;
+  volume?: number;
+}
+
+let cache = new WeakMap<THREE.Object3D, Dimensions>();
+const logged = new WeakSet<THREE.Object3D>();
+
+export async function getUnitDimensions(
+  unitRoot: THREE.Object3D,
+  _opts: { modelID?: number; expressID?: number } = {},
+): Promise<Dimensions> {
+  const cached = cache.get(unitRoot);
+  if (cached) return cached;
+
+  unitRoot.updateWorldMatrix(true, true);
+
+  let width: number | undefined;
+  let depth: number | undefined;
+  let height: number | undefined;
+  let area: number | undefined;
+  let volume: number | undefined;
+  let source: "qto" | "box" = "box";
+  let hasBQ = false;
+
+  const group = unitRoot as any as FRAGS.FragmentsGroup;
+
+  try {
+    const qsets = await group.getAllPropertiesOfType?.(
+      WEBIFC.IFCELEMENTQUANTITY,
+    );
+    if (qsets) {
+      for (const qset of Object.values(qsets) as any[]) {
+        const qname = String(qset.Name?.value || "")
+          .toLowerCase()
+          .replace(/\s+/g, "");
+        if (
+          qname === "basequantities" ||
+          qname.startsWith("qto_") ||
+          qname.includes("basequant")
+        ) {
+          const ids = await IfcPropertiesUtils.getQsetQuantities(
+            group,
+            qset.expressID,
+          );
+          if (ids) {
+            hasBQ = true;
+            for (const id of ids) {
+              const q = await group.getProperties(id);
+              const name = String(q?.Name?.value || "").toLowerCase();
+              const { value } = await IfcPropertiesUtils.getQuantityValue(
+                group,
+                id,
+              );
+              const num = Number(value);
+              if (Number.isNaN(num)) continue;
+              if (name === "width") width = num;
+              else if (name === "length" || name === "depth") depth = num;
+              else if (name === "height") height = num;
+              else if (name.includes("area")) area = num;
+              else if (name.includes("volume")) volume = num;
+            }
+          }
+          break;
+        }
+      }
+    }
+  } catch {
+    /* empty */
+  }
+
+  if (width !== undefined && depth !== undefined && height !== undefined)
+    source = "qto";
+
+  if (
+    width === undefined ||
+    depth === undefined ||
+    height === undefined ||
+    area === undefined ||
+    volume === undefined
+  ) {
+    const box = new THREE.Box3().setFromObject(unitRoot);
+    const size = box.getSize(new THREE.Vector3());
+    width ??= size.x;
+    depth ??= size.z;
+    height ??= size.y;
+    area ??= width * depth;
+    volume ??= width * depth * height;
+    if (source !== "qto") source = "box";
+    if (import.meta.env.DEV && !logged.has(unitRoot)) {
+      console.info("[dims] Box3", size);
+    }
+  }
+
+  const round = (n: number) => Math.round(n * 100) / 100;
+  const result: Dimensions = {
+    width: round(width ?? 0),
+    depth: round(depth ?? 0),
+    height: round(height ?? 0),
+  };
+  if (area !== undefined) result.area = round(area);
+  if (volume !== undefined) result.volume = round(volume);
+  cache.set(unitRoot, result);
+
+  if (import.meta.env.DEV && !logged.has(unitRoot)) {
+    console.info(
+      "[dims] BaseQuantities:",
+      hasBQ,
+      "source:",
+      source,
+    );
+    logged.add(unitRoot);
+  }
+
+  return result;
+}
+
+export function clearDimensionsCache(root?: THREE.Object3D): void {
+  if (root) cache.delete(root);
+  else cache = new WeakMap();
+}

--- a/packages/viewer/src/logic/dimensions.ts
+++ b/packages/viewer/src/logic/dimensions.ts
@@ -9,6 +9,7 @@ export interface Dimensions {
   height: number;
   area?: number;
   volume?: number;
+  source: "qto" | "box";
 }
 
 let cache = new WeakMap<THREE.Object3D, Dimensions>();
@@ -30,6 +31,7 @@ export async function getUnitDimensions(
   let volume: number | undefined;
   let source: "qto" | "box" = "box";
   let hasBQ = false;
+  let boxSize: THREE.Vector3 | undefined;
 
   const group = unitRoot as any as FRAGS.FragmentsGroup;
 
@@ -88,16 +90,13 @@ export async function getUnitDimensions(
     volume === undefined
   ) {
     const box = new THREE.Box3().setFromObject(unitRoot);
-    const size = box.getSize(new THREE.Vector3());
-    width ??= size.x;
-    depth ??= size.z;
-    height ??= size.y;
+    boxSize = box.getSize(new THREE.Vector3());
+    width ??= boxSize.x;
+    depth ??= boxSize.z;
+    height ??= boxSize.y;
     area ??= width * depth;
     volume ??= width * depth * height;
     if (source !== "qto") source = "box";
-    if (import.meta.env.DEV && !logged.has(unitRoot)) {
-      console.info("[dims] Box3", size);
-    }
   }
 
   const round = (n: number) => Math.round(n * 100) / 100;
@@ -105,18 +104,14 @@ export async function getUnitDimensions(
     width: round(width ?? 0),
     depth: round(depth ?? 0),
     height: round(height ?? 0),
+    source,
   };
   if (area !== undefined) result.area = round(area);
   if (volume !== undefined) result.volume = round(volume);
   cache.set(unitRoot, result);
 
   if (import.meta.env.DEV && !logged.has(unitRoot)) {
-    console.info(
-      "[dims] BaseQuantities:",
-      hasBQ,
-      "source:",
-      source,
-    );
+    console.info("[dims]", { box: boxSize, qtoFound: hasBQ, source });
     logged.add(unitRoot);
   }
 

--- a/packages/viewer/styles.css
+++ b/packages/viewer/styles.css
@@ -76,6 +76,16 @@ body {
 .panel{display:none;height:calc(100% - 32px);overflow:auto;padding:4px;}
 .panel.active{display:block;}
 
+.param-banner{
+  background:#fffa8b;
+  border:1px solid #e0c200;
+  padding:8px;
+  border-radius:4px;
+  margin-bottom:8px;
+  font-size:12px;
+}
+.param-banner button{margin:2px 4px 0 0;}
+
 #unitList{
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/packages/viewer/utils/thumbnail.ts
+++ b/packages/viewer/utils/thumbnail.ts
@@ -14,17 +14,18 @@ export async function generateThumbnail(source: string | THREE.Object3D): Promis
   let root: THREE.Object3D;
 
   try {
-    if (typeof source === 'string') {
-      console.log(`[IFC] thumbnail load ${source}`);
-      const bytes = await loadIfcBytes(source);
-      const comps = new OBC.Components();
-      const loader = comps.get(OBC.IfcLoader as any);
-      if (loader?.setup) await loader.setup();
-      const model: any = await loader.load(bytes.slice() as any);
-      root = model?.mesh || model?.root || model?.object || model;
-    } else {
-      root = source;
-    }
+      if (typeof source === 'string') {
+        console.log(`[IFC] thumbnail load ${source}`);
+        const bytes = await loadIfcBytes(source);
+        const comps = new OBC.Components();
+        const loader = comps.get(OBC.IfcLoader as any);
+        if (loader?.settings) loader.settings.wasm = { path: '/wasm/', absolute: true } as any;
+        if (loader?.setup) await loader.setup();
+        const model: any = await loader.load(bytes.slice() as any);
+        root = model?.mesh || model?.root || model?.object || model;
+      } else {
+        root = source;
+      }
   } catch (error) {
     console.warn(`[IFC] thumbnail failed for ${source}`, error);
     return PLACEHOLDER;

--- a/packages/viewer/utils/thumbnail.ts
+++ b/packages/viewer/utils/thumbnail.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
+import * as OBC from '@thatopen/components';
 import { FragmentsGroup } from '@thatopen/fragments';
-import { loadIfc } from '../src/ifc/loader';
+import { loadIfcBytes } from '../src/ifc/loader';
 
 const thumbSize = { width: 160, height: 120 };
 const PLACEHOLDER = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAGgwJ/lqY5WQAAAABJRU5ErkJggg==';
@@ -15,8 +16,12 @@ export async function generateThumbnail(source: string | THREE.Object3D): Promis
   try {
     if (typeof source === 'string') {
       console.log(`[IFC] thumbnail load ${source}`);
-      const { root: r } = await loadIfc(source);
-      root = r;
+      const bytes = await loadIfcBytes(source);
+      const comps = new OBC.Components();
+      const loader = comps.get(OBC.IfcLoader as any);
+      if (loader?.setup) await loader.setup();
+      const model: any = await loader.load(bytes.slice() as any);
+      root = model?.mesh || model?.root || model?.object || model;
     } else {
       root = source;
     }


### PR DESCRIPTION
## Summary
- highlight ParameterTest property with clip & transparency actions
- display unit width × depth × height plus area and volume

## Testing
- `yarn test --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a48654e8308330a4f52ccf55904a76