### PR TITLE
feat(viewer): toggle IFC elements by parameter groups

### DIFF
--- a/packages/viewer/ifc/parameter-visibility.test.ts
+++ b/packages/viewer/ifc/parameter-visibility.test.ts
@@ -1,0 +1,48 @@
+import * as THREE from 'three';
+import { buildParamGroups, Label } from './parameter-visibility';
+
+describe('buildParamGroups', () => {
+  test('collects objects by ParameterTest value', async () => {
+    const mesh = new THREE.Mesh();
+    mesh.userData.expressID = 10;
+    const root = new THREE.Object3D();
+    root.add(mesh);
+
+    const ifcAPI = {
+      IFCRELDEFINESBYPROPERTIES: 1,
+      GetLineIDsWithType: () => [1],
+      GetLine: (_model: number, id: number) => {
+        if (id === 1) return { RelatedObjects: [{ value: 10 }], RelatingPropertyDefinition: { value: 2 } };
+        if (id === 2) return { HasProperties: [{ value: 3 }] };
+        if (id === 3) return { Name: { value: 'ParameterTest' }, NominalValue: { value: 'AA' } };
+        return null;
+      },
+    } as any;
+
+    const groups = await buildParamGroups(ifcAPI, 0, root);
+    expect(groups.map.get('AA')?.has(mesh)).toBe(true);
+  });
+
+  test('toggle changes visibility', async () => {
+    const mesh = new THREE.Mesh();
+    mesh.userData.expressID = 20;
+    const root = new THREE.Object3D();
+    root.add(mesh);
+
+    const ifcAPI = {
+      IFCRELDEFINESBYPROPERTIES: 1,
+      GetLineIDsWithType: () => [1],
+      GetLine: (_model: number, id: number) => {
+        if (id === 1) return { RelatedObjects: [{ value: 20 }], RelatingPropertyDefinition: { value: 2 } };
+        if (id === 2) return { HasProperties: [{ value: 3 }] };
+        if (id === 3) return { Name: { value: 'ParameterTest' }, NominalValue: { value: 'BB' } };
+        return null;
+      },
+    } as any;
+
+    const groups = await buildParamGroups(ifcAPI, 0, root);
+    groups.toggle('BB', false);
+    expect(mesh.visible).toBe(false);
+  });
+});
+

--- a/packages/viewer/ifc/parameter-visibility.ts
+++ b/packages/viewer/ifc/parameter-visibility.ts
@@ -1,0 +1,76 @@
+import type { IfcAPI } from 'web-ifc';
+import * as THREE from 'three';
+
+export type Label = 'AA' | 'BB' | 'CC' | 'DD';
+
+export interface ParamGroups {
+  map: Map<Label, Set<THREE.Object3D>>;
+  labels: Label[];
+  toggle: (label: Label, visible: boolean) => void;
+}
+
+function toString(val: any): string | null {
+  if (val == null) return null;
+  if (typeof val === 'string') return val;
+  if (typeof val.value === 'string') return val.value;
+  if (typeof val.wrappedValue === 'string') return val.wrappedValue;
+  return String(val);
+}
+
+export async function buildParamGroups(
+  ifcAPI: IfcAPI,
+  modelID: number,
+  root: THREE.Object3D,
+): Promise<ParamGroups> {
+  const labels: Label[] = ['AA', 'BB', 'CC', 'DD'];
+  const map = new Map<Label, Set<THREE.Object3D>>();
+  labels.forEach(l => map.set(l, new Set()));
+
+  // Build expressID -> Object3D index
+  const index = new Map<number, THREE.Object3D>();
+  root.traverse(obj => {
+    const id = (obj as any).userData?.expressID ?? (obj as any).userData?.ifcId;
+    if (typeof id === 'number') index.set(id, obj);
+  });
+
+  if (!ifcAPI) {
+    return { map, labels, toggle };
+  }
+
+  const relIDs: Iterable<number> = (ifcAPI as any).GetLineIDsWithType
+    ? (ifcAPI as any).GetLineIDsWithType(modelID, (ifcAPI as any).IFCRELDEFINESBYPROPERTIES)
+    : [];
+
+  for (const relID of Array.from(relIDs as any)) {
+    const rel: any = (ifcAPI as any).GetLine(modelID, relID);
+    if (!rel) continue;
+    const related: any[] = rel.RelatedObjects || [];
+    const propDef = rel.RelatingPropertyDefinition?.value;
+    if (!propDef) continue;
+    const pset: any = (ifcAPI as any).GetLine(modelID, propDef);
+    const hasProps: any[] = pset?.HasProperties || [];
+    for (const pRef of hasProps) {
+      const prop: any = (ifcAPI as any).GetLine(modelID, pRef.value);
+      if (!prop || prop.Name?.value !== 'ParameterTest') continue;
+      const text = toString(prop.NominalValue)?.toUpperCase();
+      if (!text || !map.has(text as Label)) continue;
+      const set = map.get(text as Label)!;
+      for (const r of related) {
+        const eid = typeof r === 'number' ? r : r.value;
+        const obj = index.get(eid);
+        if (obj) set.add(obj);
+      }
+    }
+  }
+
+  function toggle(label: Label, visible: boolean) {
+    const set = map.get(label);
+    if (!set) return;
+    set.forEach(o => {
+      o.visible = visible;
+    });
+  }
+
+  return { map, labels, toggle };
+}
+

--- a/packages/viewer/index.ts
+++ b/packages/viewer/index.ts
@@ -11,6 +11,8 @@ import { toUint8Array } from "./src/ifc/bytes";
 import { buildIndex, picked, byStorey } from "./src/ifc";
 import { setStoreys } from "./src/ifc/storeys";
 import { generateThumbnail } from "./utils/thumbnail";
+import { buildParamGroups } from "./ifc/parameter-visibility";
+import { mountIfcToggles } from "./ui/ifc-toggles";
 // Helper modules defined in this package
 //  - sidebar.ts: collects model metadata and renders the info sidebar
 //  - levels.ts: manages floor grids and level switching
@@ -949,6 +951,7 @@ export async function bootstrap() {
   const paintMenu = document.getElementById("paintMenu") as HTMLDivElement | null;
   const paintBtn = document.getElementById("paintBtn") as HTMLButtonElement | null;
   const resetBtn = document.getElementById("resetBtn") as HTMLButtonElement | null;
+  let ifcAPI: any = null;
   initSidebar();
   sidebarEl = document.getElementById("sidebar") as HTMLElement | null;
   const placedList = document.getElementById("placedList") as HTMLUListElement | null;
@@ -1008,7 +1011,8 @@ export async function bootstrap() {
   });
 
   bboxer = components.get(OBC.BoundingBoxer);
-  await setupIfc(world);
+  const ifcLoader = await setupIfc(world);
+  ifcAPI = (ifcLoader as any)?.ifcManager?.ifcAPI;
 
   const gridPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
   initFloors(world, gridPlane);
@@ -1287,6 +1291,15 @@ export async function bootstrap() {
     addCartItem(root);
     await buildIndex({ modelID, root });
     setStoreys(byStorey);
+
+    if (ifcAPI) {
+      try {
+        const groups = await buildParamGroups(ifcAPI, modelID, world.scene.three);
+        mountIfcToggles(groups);
+      } catch (err) {
+        console.warn('[IFC] ParameterTest parsing failed', err);
+      }
+    }
 
     totalWidth += dims.width;
     totalHeight += dims.height;

--- a/packages/viewer/ui/ifc-toggles.ts
+++ b/packages/viewer/ui/ifc-toggles.ts
@@ -1,0 +1,46 @@
+import type { ParamGroups, Label } from '../ifc/parameter-visibility';
+
+export function mountIfcToggles(groups: ParamGroups) {
+  const labels = groups.labels;
+  const active = labels.some(l => (groups.map.get(l)?.size ?? 0) > 0);
+  const existing = document.getElementById('ifcParamPanel');
+  existing?.remove();
+  if (!active) return;
+
+  const panel = document.createElement('div');
+  panel.id = 'ifcParamPanel';
+  Object.assign(panel.style, {
+    position: 'fixed',
+    top: '10px',
+    left: '10px',
+    zIndex: '20',
+    background: 'rgba(255,255,255,0.9)',
+    border: '1px solid #ccc',
+    padding: '4px',
+    display: 'flex',
+    gap: '4px',
+  });
+
+  const state: Record<Label, boolean> = { AA: true, BB: true, CC: true, DD: true };
+
+  labels.forEach(label => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = label;
+    btn.style.padding = '2px 6px';
+    const set = groups.map.get(label);
+    if (!set || set.size === 0) {
+      btn.disabled = true;
+      btn.title = 'No elements';
+    }
+    btn.addEventListener('click', () => {
+      state[label] = !state[label];
+      groups.toggle(label, state[label]);
+      btn.style.opacity = state[label] ? '1' : '0.5';
+    });
+    panel.appendChild(btn);
+  });
+
+  document.body.appendChild(panel);
+}
+


### PR DESCRIPTION
## Summary
- map IFC `ParameterTest` properties to AA/BB/CC/DD groups for fast visibility toggling
- add small UI panel to toggle groups
- hook group building after IFC load and mount the panel

## Testing
- `yarn typecheck` *(fails: Couldn't find a script named "typecheck")*
- `npx jest packages/viewer/ifc/parameter-visibility.test.ts --config '{"preset":"ts-jest","testEnvironment":"node"}'`


------
https://chatgpt.com/codex/tasks/task_e_68a599e336dc832db669945b6b642677